### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,33 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: v1/
+
+      - id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- `v1/` ディレクトリを GitHub Pages にデプロイする GitHub Actions ワークフローを追加
- `main` ブランチへの push で自動デプロイ
- デプロイ先: https://oshiro-kazuma.github.io/syougi.js/

## Test plan
- [ ] GitHub リポジトリの Settings → Pages → Source を "GitHub Actions" に変更
- [ ] PR マージ後、Actions タブでデプロイが成功することを確認
- [ ] https://oshiro-kazuma.github.io/syougi.js/ でページが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)