### PR TITLE
Fix README: screenshot path and GitHub Pages link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
 ## syougi.js
 
-![screen shot](screen_shot.png)
+![screen shot](v1/screen_shot.png)
 
 JavaScript, jQueryを使った将棋のコード。
 
-### demo
-
-http://www.takuan.me/syougi/
+https://oshiro-kazuma.github.io/syougi.js/
 
 ### 使い方
 


### PR DESCRIPTION
## Summary
- スクリーンショットのパスを `screen_shot.png` → `v1/screen_shot.png` に修正
- demo セクション（リンク切れ）を削除
- GitHub Pages URL を追加: https://oshiro-kazuma.github.io/syougi.js/

🤖 Generated with [Claude Code](https://claude.com/claude-code)